### PR TITLE
33 set up bot keeping track of days since on boarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,20 @@ Telegram bot for Wisper project GEMH Lab.
 
 - `echobot.py`: Main bot conversation sequence
 - `chat.py`: Includes ChatHandler class which handles communicating with the user and logging
+
+## Configuration
+
+Create a `.env` file.
+Options allow you to disable transcription, disable sending of videos, set the start date for an experiment, set how long a "day" lasts, and optionally set the status the bot starts from (for testing purposes).
+
+Sample:
+
+```bash
+TELEGRAM_TOKEN = 'your_telegram_token'
+OPENAI_API_KEY = 'your_openai_key'
+TRANSCRIBE = 'False'
+VIDEO = 'False'
+START_DATE = datetime(2024,4,16,22,22)
+INTERVAL = 'timedelta(seconds=120)'
+STARTING_STATUS = 'WEEK1_PROMPT1'
+```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ TELEGRAM_TOKEN = 'your_telegram_token'
 OPENAI_API_KEY = 'your_openai_key'
 TRANSCRIBE = 'False'
 VIDEO = 'False'
-START_DATE = datetime(2024,4,16,22,22)
+START_DATE = 'datetime(2024,4,16,22,22)'
 INTERVAL = 'timedelta(seconds=120)'
 STARTING_STATUS = 'WEEK1_PROMPT1'
 ```

--- a/chat.py
+++ b/chat.py
@@ -255,7 +255,6 @@ class ChatHandler:
     # this will call either send_msg or send_vn
     async def send_now(self, context=None, VN=None, Text=None, status=None):
         '''Send a voicenote file or message, either scheduled or now'''
-        self.status = status
         try:
             update = context.job.data['update']
             VN = context.job.data['VN']
@@ -263,6 +262,7 @@ class ChatHandler:
             status = context.job.data['status']
         except AttributeError:
             pass
+        self.status = status
         if Text:
             await self.send_msg(Text)
         if VN:

--- a/chat.py
+++ b/chat.py
@@ -245,7 +245,7 @@ class ChatHandler:
             data={'update': self.update, 'VN': VN, 'Text': Text}
         )
     
-    async def vn(self, send_time = START_DATE, VN, Text):
+    async def vn(self, send_time, VN, Text):
         now = datetime.now()
         if now > send_time:
             await self.send_vn(VN=VN,Text=Text)

--- a/chat.py
+++ b/chat.py
@@ -252,6 +252,17 @@ class ChatHandler:
         else:
             await self.schedule_vn(send_time=send_time,VN=VN,Text=Text)
 
+    async def exchange_vns(self, paired_chat, status, Text):
+            chat = self
+
+            for c, oc in [(chat,paired_chat),(paired_chat,chat)]:
+                query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{oc.chat_id}' and event='recv_vn' AND status='{status}'")
+                intro_file = query[0]
+                c.log(f'Trying to send {intro_file}')
+                await c.vn(send_time=datetime.now(),VN=intro_file,Text=f'{Text} Here is your message from {oc.first_name}:')
+                c.status = 'intros_complete'
+                await c.send_msg(f"Onboarding complete!")
+
     async def transcribe(self,filename):
         if not TRANSCRIBE:
             return None

--- a/chat.py
+++ b/chat.py
@@ -220,7 +220,7 @@ class ChatHandler:
         if VIDEO:
             while True:
                 try:
-                    await self.context.bot.send_video(chat_id=self.chat_id, video=open(FN, 'rb'), caption="Click to start, and make sure your sound is on. 🔊👍🏻", has_spoiler=True, width=1280, height=720)
+                    await self.context.bot.send_video(chat_id=self.chat_id, video=open(FN, 'rb'), caption="Click to start, and make sure your sound is on. ����👍🏻", has_spoiler=True, width=1280, height=720)
                     self.log_send_video(FN)
                     break
                 except TimedOut:
@@ -312,7 +312,7 @@ class ChatHandler:
         if img:
             await self.send_img(img)
     
-    async def schedule(self, send_time, VN, Text, img, status):
+    async def schedule(self, send_time, VN, Text, img, status, misfire_grace_time=None):
         self.log(f"Scheduled sending of {VN} and message '{Text}' at {send_time}")
         now = datetime.now()
         delay = (send_time - now).total_seconds()
@@ -320,7 +320,7 @@ class ChatHandler:
             self.send_now,
             delay,
             data={'update': self.update, 'VN': VN, 'Text': Text, 'img': img, 'status': status, 'scheduled_time': send_time},
-            misfire_grace_time=300
+            job_kwargs={'misfire_grace_time': misfire_grace_time}
         )
     
     async def send(self, send_time=None, VN=None, Text=None, img=None, status=None):

--- a/chat.py
+++ b/chat.py
@@ -335,19 +335,13 @@ class ChatHandler:
             c.log(f'Trying to send {file}')
             await c.send(send_time=datetime.now(),VN=file,Text=f'{Text} Here is your message from {oc.first_name}:')
     
-    async def get_story_audio(self):
+    async def get_audio(self,status):
         chat = self
-        query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{chat.chat_id}' and event='recv_vn' AND status='received_week1_story'")
+        query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{chat.chat_id}' and event='recv_vn' AND status='{status}'")
         file = query[0]
-        chat.log(f'Story audio file is {file}')
+        chat.log(f'{status} audio file is {file}')
         return file
-    
-    async def get_vt_audio(self):
-        chat = self
-        query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{chat.chat_id}' and event='recv_vn' AND status='received_week1_vt'")
-        file = query[0]
-        chat.log(f'Value tensions audio file is {file}')
-        return file
+   
 
     async def transcribe(self,filename):
         if not TRANSCRIBE:

--- a/chat.py
+++ b/chat.py
@@ -245,7 +245,7 @@ class ChatHandler:
             data={'update': self.update, 'VN': VN, 'Text': Text}
         )
     
-    async def vn(self, send_time, VN, Text):
+    async def vn(self, send_time = START_DATE, VN, Text):
         now = datetime.now()
         if now > send_time:
             await self.send_vn(VN=VN,Text=Text)

--- a/chat.py
+++ b/chat.py
@@ -295,8 +295,14 @@ class ChatHandler:
             Text = context.job.data['Text']
             img = context.job.data['img']
             status = context.job.data['status']
+            scheduled_time = context.job.data['scheduled_time']
+            # Check if the current time is significantly past the scheduled time
+            now = datetime.now()
+            if scheduled_time and (now - scheduled_time).total_seconds() > 5:
+                self.log(f"Missed scheduled time by {(now - scheduled_time).total_seconds()} seconds. Sending now.")
         except AttributeError:
             pass
+
         if status:
             self.status = status
         if Text:
@@ -313,7 +319,8 @@ class ChatHandler:
         self.context.job_queue.run_once(
             self.send_now,
             delay,
-            data={'update': self.update, 'VN': VN, 'Text': Text, 'img': img, 'status': status}
+            data={'update': self.update, 'VN': VN, 'Text': Text, 'img': img, 'status': status, 'scheduled_time': send_time},
+            misfire_grace_time=300
         )
     
     async def send(self, send_time=None, VN=None, Text=None, img=None, status=None):

--- a/chat.py
+++ b/chat.py
@@ -110,14 +110,22 @@ class ChatHandler:
         except FileNotFoundError:
             self.number = None
         self.logger = self.get_logger()# Set the paired user during initialization
-        self.set_paired_user()  
 
-    def set_paired_user(self):
+    def set_paired_user(self, chat_handlers):
         '''Set the paired user based on the chat's username'''
         self.paired_user = user_pairs.get(self.name, None)
         self.log(f'Paired user set to {self.paired_user}')
         self.paired_chat_id = name_to_chat_id.get(self.paired_user, None)
         self.log(f'Paired user id is {self.paired_chat_id}')
+        try:
+            chat = chat_handlers[self.paired_chat_id]
+            chat.paired_user = self.name
+            chat.log(f'Paired user set to {self.name}')
+            chat.paired_chat_id = self.chat_id
+            chat.log(f'Paired user id is {self.chat_id}')
+        except KeyError:
+            self.log(f'Paired chat id not yet found: {self.paired_user}')
+            pass
 
     @property
     def status(self):

--- a/chat.py
+++ b/chat.py
@@ -1,6 +1,6 @@
 ###---------LIBRARY IMPORTS---------###
 import csv
-from datetime import datetime
+from datetime import datetime, timedelta
 import dotenv
 import logging
 import os
@@ -199,6 +199,12 @@ class ChatHandler:
 
                 # Wait a few seconds before retrying
                 await asyncio.sleep(5)
+    
+    async def send_msgs(self, messages, send_time):
+        await self.send_msg(f"Next prompt will be sent at {send_time}")
+        for msg in messages:
+            send_time = send_time + timedelta(seconds=1)
+            await self.send(send_time=send_time, Text=msg)
 
     async def send_video(self,FN):
         '''Send a video file, try infinitely'''

--- a/chat.py
+++ b/chat.py
@@ -262,7 +262,8 @@ class ChatHandler:
             status = context.job.data['status']
         except AttributeError:
             pass
-        self.status = status
+        if status:
+            self.status = status
         if Text:
             await self.send_msg(Text)
         if VN:
@@ -283,19 +284,19 @@ class ChatHandler:
         # If send_time is None or in the past, send immediately
         if not send_time or now > send_time:
             await self.send_now(VN=VN,Text=Text)
-            self.status = status
+            if status:
+                self.status = status
         else:
             # Otherwise, schedule the send
             await self.schedule(send_time=send_time,VN=VN,Text=Text,status=status)
 
     async def exchange_vns(self, paired_chat, status, Text):
             chat = self
-
             for c, oc in [(chat,paired_chat),(paired_chat,chat)]:
                 query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{oc.chat_id}' and event='recv_vn' AND status='{status}'")
-                intro_file = query[0]
-                c.log(f'Trying to send {intro_file}')
-                await c.send(send_time=datetime.now(),VN=intro_file,Text=f'{Text} Here is your message from {oc.first_name}:')
+                file = query[0]
+                c.log(f'Trying to send {file}')
+                await c.send(send_time=datetime.now(),VN=file,Text=f'{Text} Here is your message from {oc.first_name}:')
 
     async def transcribe(self,filename):
         if not TRANSCRIBE:

--- a/chat.py
+++ b/chat.py
@@ -230,9 +230,9 @@ class ChatHandler:
             pass
         self.log_event(sender='bot',recver=self.name,recv_id='',event='send_vn',filename=VN)
         self.sent.append(VN)
-        await self.context.bot.send_voice(chat_id=self.chat_id, voice=VN)
         if Text:
             await self.send_msg(Text)
+        await self.context.bot.send_voice(chat_id=self.chat_id, voice=VN)
         self.log(f'Sent {VN}')
     
     async def schedule_vn(self, send_time, VN, Text):

--- a/echobot.py
+++ b/echobot.py
@@ -110,6 +110,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
         return
     bot = chat.context.bot
+    chat.log_recv_text('/start command')
     if STARTING_STATUS:
         chat.log(f'Skipping to {STARTING_STATUS}')
         await chat.send_msg(f'Based on bot\'s .env file, skipping to {STARTING_STATUS}', parse_mode=ParseMode.HTML)
@@ -125,7 +126,6 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await chat.send_video('explainer.mp4')
         await chat.send_msg(f"""Once you have watched the video, enter /starttutorial for further instructions. 😊""")
         chat.status = 'start_welcomed'
-        chat.log_recv_text('Received /start')
         return START_WELCOMED
 
 async def start_tutorial(update, context):
@@ -223,8 +223,10 @@ async def awaiting_intro(update, context):
 
             send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):
+                c.status = 'intros_complete'
+                await c.send_msg(f"Onboarding complete!")
                 await c.send_msg(f"Next prompt will be sent at {send_time}")
-                await c.vn(send_time=send_time,VN='prompts/prompt1.ogg',Text='Welcome to Day 1! Here is prompt 1. Please record a story.')
+                await c.send(send_time=send_time,VN=None,Text='Welcome to Day 1! Here is prompt 1. Please record a story.')
                 c.status = 'week1_prompt1_sent'
 
             return WEEK1_PROMPT1
@@ -246,7 +248,7 @@ async def week1_prompt1(update, context):
         send_time = START_DATE + INTERVAL
         for c in (chat,paired_chat):
             await c.send_msg(f"Next prompt will be sent at {send_time}")
-            await c.vn(send_time=send_time,VN='prompts/prompt1.ogg',Text='Welcome to Day 1! Here is prompt 1. Please record a story.')
+            await c.send(send_time=send_time,VN=None,Text='Welcome to Day 1! Here is prompt 1. Please record a story.')
             c.status = 'week1_prompt1_sent'
 
         return WEEK1_VT

--- a/echobot.py
+++ b/echobot.py
@@ -211,8 +211,11 @@ async def awaiting_intro(update, context):
         # Check the database to see if the other user has sent in their introduction
         if not chat.paired_chat_id:
             chat.set_paired_user()
-            paired_chat = chat_handlers[chat.paired_chat_id]
-            paired_chat.set_paired_user()
+            try:
+                paired_chat = chat_handlers[chat.paired_chat_id]
+                paired_chat.set_paired_user()
+            except KeyError:
+                pass
             await chat.send_msg(f"Your partner has not yet sent their introduction. You'll receive it as soon as they send it in!")
         else:
             paired_chat = chat_handlers[chat.paired_chat_id]

--- a/echobot.py
+++ b/echobot.py
@@ -262,30 +262,31 @@ async def week1_prompt1(update, context):
 async def week1_vt(update, context):
     '''Handle the response for week 1 value tension reflection'''
     chat = await initialize_chat_handler(update, context)
-    chat.subdir = 'week1_vt'
+    chat.subdir = 'received_week1_vt'
     if update.message.voice:
+        chat.status = 'received_week1_vt'
         await get_voicenote(update, context)
         await chat.send_msg(f"Thank you for sending in your second audio reflection, {chat.first_name}!")
         await chat.send_msg("Now that you have reflected on your life and the value tensions therein, you and your Echo partner will both receive each other's stories tomorrow morning.")
         await chat.send_msg("Stay tuned, you will receive continue the Echo journey tomorrow.")
         paired_chat = chat_handlers[chat.paired_chat_id]
-        if paired_chat.status == 'week1_vt':
-            await chat.exchange_vns(paired_chat, status='week1_vt', text=f"Both partners have completed their reflections!")
+        if paired_chat.status == 'received_week1_vt':
             send_time = START_DATE + INTERVAL
-            for c in (chat, paired_chat):
-                c.status = 'day2_complete'
-                await c.send_msg(f"Day 2 complete!")
-            messages = [
-                "Hi there! Your partner and you both have recorded your story and value tension reflections. Time to listen to your partner's audio!",
-                "Here is your partner's initial personal story.",
-                f"audio:{paired_chat.get_story_audio()}",
-                "Here is your partner's value tension reflection on that story.",
-                f"audio:{paired_chat.get_vt_audio()}",
-                "Now, it's important that you listen to these stories as you would to a good friend. Echo is all about 'curious listening', which means that we listen to understand. After having listened to your partner's story and value tension reflection, make sure you try to paraphrase your partner's story in your own words, and ask clarifying questions. That way, your partner will truly feel heard!",
-                "Go ahead and record your 'curious listening' response to your partner's stories when you are ready. Make sure you do so before the end of tomorrow."
-            ]
-            await chat.send_msgs(messages, send_time)
-            chat.status = 'awaiting_curious_listening_response'
+            for c, oc in [(chat,paired_chat),(paired_chat,chat)]:
+                c.status = 'day3_complete'
+                await c.send_msg(f"Your partner has sent in their reflection.")
+                await c.send_msg(f"Day 3 complete!")
+                messages = [
+                    "Hi there! Your partner and you both have recorded your story and value tension reflections. Time to listen to your partner's audio!",
+                    "Here is your partner's initial personal story.",
+                    f"audio:{await oc.get_story_audio()}",
+                    "Here is your partner's value tension reflection on that story.",
+                    f"audio:{await oc.get_vt_audio()}",
+                    "Now, it's important that you listen to these stories as you would to a good friend. Echo is all about 'curious listening', which means that we listen to understand. After having listened to your partner's story and value tension reflection, make sure you try to paraphrase your partner's story in your own words, and ask clarifying questions. That way, your partner will truly feel heard!",
+                    "Go ahead and record your 'curious listening' response to your partner's stories when you are ready. Make sure you do so before the end of tomorrow."
+                ]
+                await c.send_msgs(messages, send_time)
+                c.status = 'awaiting_listening_response'
         else:
             # This needs fixing:
             await chat.send_msg(f"Your partner has not yet completed their reflection. You'll receive it as soon as they do!")

--- a/echobot.py
+++ b/echobot.py
@@ -202,7 +202,7 @@ async def awaiting_intro(update, context):
         await get_voicenote(update, context)
         # Check the database to see if the other user has sent in their introduction
         if not chat.paired_chat_id:
-            await chat.send_msg(f"Your partner has not yet sent their introduction. You'll receive it as soon as they send it in!")
+            await chat.send_msg(f"Your partner has not initiated a conversation with me. You'll receive their introduction as soon as I receive it!")
             return WEEK1_PROMPT1
         else:
             paired_chat = chat_handlers[chat.paired_chat_id]
@@ -211,7 +211,6 @@ async def awaiting_intro(update, context):
                 await chat.exchange_vns(paired_chat, status='received_intro', Text=f"Your partner has also sent in their introduction!")
             else:
                 await chat.send_msg(f"Your partner has not yet sent their introduction. You'll receive it as soon as they send it in!")
-                return WEEK1_PROMPT1
 
             send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):

--- a/echobot.py
+++ b/echobot.py
@@ -20,6 +20,12 @@ from telegram.constants import ParseMode
 dotenv.load_dotenv()
 TOKEN = os.environ.get("TELEGRAM_TOKEN")
 STARTING_STATUS = os.environ.get("STARTING_STATUS")
+try:
+    START_DATE = eval(os.environ.get("START_DATE"))
+except TypeError:
+    START_DATE = datetime.now()
+    print('Warning! START_DATE not set to a datetime(YYYY,MM,DD,HH,MM) value in .env file. Using now as START_DATE')
+print(f'START_DATE is {START_DATE}')
 
 ###---------CONVERSATION HANDLER SETUP---------###
 states = ['START_WELCOMED',

--- a/echobot.py
+++ b/echobot.py
@@ -250,6 +250,7 @@ async def week1_prompt1(update, context):
                 messages = [
                     "Welcome back! Yesterday you recorded a personal story. Today, we would like you to listen to your own story, and think about whether and how you have had to balance between different values. This balancing is what we call ‘value tensions’.",
                     "Here are some examples of value tensions.",
+                    'img:vt.png',
                     "In today's part of the Echo experience, we would like you to reflect on how you would place yourself on one or two of the following value tensions, and send this to your Echo partner in an audio message. Note that you do not need to cover all of these tension; just pick one or two that seem relevant to the story that you recorded earlier. When you are read to record, go ahead." 
                 ]
                 await c.send_msgs(messages, send_time)

--- a/echobot.py
+++ b/echobot.py
@@ -1,5 +1,5 @@
 ###---------LIBRARY IMPORTS---------###
-from datetime import datetime
+from datetime import datetime, timedelta
 import dotenv
 import os
 import re
@@ -25,7 +25,12 @@ try:
 except TypeError:
     START_DATE = datetime.now()
     print('Warning! START_DATE not set to a datetime(YYYY,MM,DD,HH,MM) value in .env file. Using now as START_DATE')
-print(f'START_DATE is {START_DATE}')
+try:
+    INTERVAL = eval(os.environ.get("INTERVAL"))
+except TypeError:
+    INTERVAL = timedelta(hours=24)
+
+print(f'START_DATE is {START_DATE} and one "day" is {INTERVAL}')
 
 ###---------CONVERSATION HANDLER SETUP---------###
 states = ['START_WELCOMED',
@@ -225,9 +230,10 @@ async def awaiting_intro(update, context):
             await paired_chat.send_msg(f"Onboarding complete!")
             paired_chat.status = 'intros_complete'
 
-            send_time = START_DATE + timedelta(hours=24)
+            send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):
-                c.vn(send_time=send_time,VN='prompts/prompt1.ogg',Text='Prompt 1')
+                await c.send_msg(f"Next prompt will be sent at {send_time}")
+                await c.vn(send_time=send_time,VN='prompts/prompt1.ogg',Text='Welcome to Day 1! Here is prompt 1')
                 c.status = 'week1_prompt1'
 
             return WEEK1_PROMPT1

--- a/echobot.py
+++ b/echobot.py
@@ -215,7 +215,7 @@ async def awaiting_intro(update, context):
             send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):
                 c.status = 'intros_complete'
-                await c.send_msg(f"Onboarding complete!")
+                await c.send_msg(f"Day 1 complete!")
                 messages = [
                     "Welcome to the main Echo experience! You have successfully completed on-boarding, and have been already introduced to your Echo partner.",
                     "Over the course of this week, you will be exchanging audio messages and listening to one another. Today, we start with reflecting on your life and record an audio story for your partner. You will do so based on a prompt that you and your partner both will receive in a moment.",
@@ -243,11 +243,10 @@ async def week1_prompt1(update, context):
         await chat.send_msg("Stay tuned, you will receive continue the Echo journey tomorrow.")
         paired_chat = chat_handlers[chat.paired_chat_id]
         if paired_chat.status == 'received_week1_story':
-            await chat.exchange_vns(paired_chat, status='received_week1_story', Text=f"Your partner has also sent in their story!")
             send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):
-                c.status = 'day1_complete'
-                await c.send_msg(f"Day 1 complete!")
+                c.status = 'day2_complete'
+                await c.send_msg(f"Day 2 complete!")
                 messages = [
                     "Welcome back! Yesterday you recorded a personal story. Today, we would like you to listen to your own story, and think about whether and how you have had to balance between different values. This balancing is what we call 'value tensions'.",
                     "Here are some examples of value tensions.",
@@ -286,12 +285,16 @@ async def week1_vt(update, context):
                 "Go ahead and record your 'curious listening' response to your partner's stories when you are ready. Make sure you do so before the end of tomorrow."
             ]
             await chat.send_msgs(messages, send_time)
-                chat.status = 'awaiting_curious_listening_response'
+            chat.status = 'awaiting_curious_listening_response'
         else:
+            # This needs fixing:
             await chat.send_msg(f"Your partner has not yet completed their reflection. You'll receive it as soon as they do!")
         return WEEK1_PS
     else:
         await chat.send_msg("Please send a voice note response to the value tension reflection prompt.")
+
+async def week1_ps(update, context):
+    chat = await initialize_chat_handler(update, context)
 
 async def cancel(update, context):
     chat = await initialize_chat_handler(update, context)

--- a/echobot.py
+++ b/echobot.py
@@ -235,9 +235,10 @@ async def awaiting_intro(update, context):
                     "Make sure you send in your story today, your partner will be doing the same."
                 ]
                 for msg in messages:
-                    await c.send(send_time=send_time, Text=msg)
+                    send_time = send_time + timedelta(seconds=1)
+                    await c.send(send_time=send_time, Text=msg, status='week1_prompt1_sent')
 
-                c.status = 'week1_prompt1_sent'
+                c.status = 'week1_prompt1_scheduled'
 
             return WEEK1_PROMPT1
 

--- a/echobot.py
+++ b/echobot.py
@@ -202,7 +202,7 @@ async def awaiting_intro(update, context):
         await get_voicenote(update, context)
         # Check the database to see if the other user has sent in their introduction
         if not chat.paired_chat_id:
-            await chat.send_msg(f"Your partner has not initiated a conversation with me. You'll receive their introduction as soon as I receive it!")
+            await chat.send_msg(f"Your partner has not yet sent their introduction. You'll receive it as soon as they send it in!")
             return WEEK1_PROMPT1
         else:
             paired_chat = chat_handlers[chat.paired_chat_id]
@@ -211,6 +211,7 @@ async def awaiting_intro(update, context):
                 await chat.exchange_vns(paired_chat, status='received_intro', Text=f"Your partner has also sent in their introduction!")
             else:
                 await chat.send_msg(f"Your partner has not yet sent their introduction. You'll receive it as soon as they send it in!")
+                return WEEK1_PROMPT1
 
             send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):

--- a/echobot.py
+++ b/echobot.py
@@ -210,25 +210,12 @@ async def awaiting_intro(update, context):
         # Check the database to see if the other user has sent in their introduction
         if not chat.paired_chat_id:
             chat.set_paired_user()
+            paired_chat = chat_handlers[chat.paired_chat_id]
+            paired_chat.set_paired_user()
             await chat.send_msg(f"Your partner has not yet sent their introduction. You'll receive it as soon as they send it in!")
         else:
             paired_chat = chat_handlers[chat.paired_chat_id]
-            await chat.send_msg(f"Your partner, {paired_chat.first_name}, has also sent in their introduction! Here it is:")
-            query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{chat.paired_chat_id}' and event='recv_vn' AND status='received_intro'")
-            intro_file = query[0]
-            chat.log(f'Trying to send {intro_file}')
-            await chat.send_vn(VN=intro_file)
-            await chat.send_msg(f"Onboarding complete!")
-            chat.status = 'intros_complete'
-
-            # An inefficient way of doing it but let's see if it works
-            await paired_chat.send_msg(f"Your partner, {chat.first_name}, has also sent in their introduction! Here it is:")
-            query = await chat.sqlquery(f"SELECT filename FROM logs WHERE chat_id='{chat.chat_id}' and event='recv_vn' AND status='received_intro'")
-            intro_file = query[0]
-            paired_chat.log(f'Trying to send {intro_file}')
-            await paired_chat.send_vn(VN=intro_file)
-            await paired_chat.send_msg(f"Onboarding complete!")
-            paired_chat.status = 'intros_complete'
+            await chat.exchange_vns(paired_chat, status='received_intro', Text=f"Your partner has also sent in their introduction!")
 
             send_time = START_DATE + INTERVAL
             for c in (chat,paired_chat):


### PR DESCRIPTION
This version schedules messages and should run through the first week.

- **Added basic support for scheduling messages**
- **Handle start date**
- **Comments and fix voicenote sending code to use new format, required for scheduling**
- **Oops, START_DATE is not defined here**
- **Send text before VN; configurable 'days'**
- **Refactor into function that exchanges voicenotes**
- **Test first week prompt**
- **Handle missing other user**
- **Refactor to have a single send command**
- **Fix pairing logic**
- **Set statuses correctly when scheduled events occur**
- **Trying to get to VT**
- **Fix flow and status handling**
- **Working up to Value tension**
- **Support for scheduling images**
- **Draft of value tensions section, but not yet got a way of tracking story/vt audio**
- **Fix days**
- **Fix day 3 status, implement exchanging stories and value tensions**
- **Handle days 4, 5, 6**
- **Add documentation**
- **Oops I think the datetime should be in quotes**
- **Distinguish between two casees**
- **Revert "Distinguish between two casees"**
- **Try setting misfire_grace_time to 5 minutes**
- **Try setting job_kwargs instead of misfire_grace_time directly**
